### PR TITLE
Integración Firestore

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,4 +119,6 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth:19.1.0'
     implementation 'com.google.android.gms:play-services-auth:17.0.0'
 
+    implementation 'com.google.firebase:firebase-firestore:21.2.1'
+
 }

--- a/app/firestore-rules
+++ b/app/firestore-rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{userId} {
+   		allow read, write, update: if request.auth.uid == userId;
+      
+      match /{sub=**} {
+      	allow read, write, update: if request.auth.uid == userId;
+      }
+    }
+  }
+}

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -15,6 +15,14 @@
       },
       "oauth_client": [
         {
+          "client_id": "901159858673-joov4c3gnpcckqtu123qqpm00dfj1obm.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "ar.edu.unq.pdes.grupo4",
+            "certificate_hash": "6ad8ba7a163781f3bdef7b54d1a576fc78a4f4f7"
+          }
+        },
+        {
           "client_id": "901159858673-1bcaa4cvc2k04231m2amrdogdgtpsqur.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/data/BlogEntriesRepository.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/data/BlogEntriesRepository.kt
@@ -8,6 +8,9 @@ class BlogEntriesRepository(private val appDatabase: AppDatabase) {
     fun getActiveBlogEntries() =
         LiveDataReactiveStreams.fromPublisher(appDatabase.blogEntriesDao().getAll(false))
 
+    fun getBlogEntriesWith(deleted: Boolean? = null, synced: Boolean? = null) =
+        LiveDataReactiveStreams.fromPublisher(appDatabase.blogEntriesDao().getAll(deleted, synced))
+
     fun fetchLiveById(entryId: EntityID) =
         LiveDataReactiveStreams.fromPublisher(appDatabase.blogEntriesDao().loadById(entryId))
 

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/data/migrations.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/data/migrations.kt
@@ -1,0 +1,13 @@
+package ar.edu.unq.pdes.myprivateblog.data
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_1_2: Migration = object : Migration(1, 2) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("""
+            ALTER TABLE BlogEntries
+            ADD COLUMN is_synced INTEGER DEFAULT 0 NOT NULL
+        """)
+    }
+}

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/di/ApplicationComponent.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/di/ApplicationComponent.kt
@@ -18,6 +18,7 @@ import ar.edu.unq.pdes.myprivateblog.screens.posts_listing.PostsListingViewModel
 import ar.edu.unq.pdes.myprivateblog.screens.sign.OauthSignFragment
 import ar.edu.unq.pdes.myprivateblog.screens.sign.OauthSignViewModel
 import ar.edu.unq.pdes.myprivateblog.services.BlogEntriesService
+import ar.edu.unq.pdes.myprivateblog.services.BlogEntriesSyncingService
 import dagger.*
 import dagger.android.AndroidInjector
 import dagger.android.ContributesAndroidInjector
@@ -59,6 +60,12 @@ open class ApplicationModule {
     @Provides
     fun provideBlogEntriesService(blogEntriesRepository: BlogEntriesRepository, context: Context): BlogEntriesService {
         return BlogEntriesService(blogEntriesRepository, context)
+    }
+
+    @Singleton
+    @Provides
+    fun provideBlogEntriesSyncingService(blogEntriesService: BlogEntriesService, context: Context): BlogEntriesSyncingService {
+        return BlogEntriesSyncingService(blogEntriesService, context)
     }
 }
 

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/services/BlogEntriesService.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/services/BlogEntriesService.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.LiveData
 import ar.edu.unq.pdes.myprivateblog.data.BlogEntriesRepository
 import ar.edu.unq.pdes.myprivateblog.data.BlogEntry
+import ar.edu.unq.pdes.myprivateblog.data.EntityID
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -18,26 +19,30 @@ class BlogEntriesService @Inject constructor(
     fun fetch(id: Int) : Flowable<BlogEntry> {
         return blogEntriesRepository
             .fetchById(id)
-    } 
- 
+    }
+
     fun getAll(): LiveData<List<BlogEntry>>{
         return blogEntriesRepository.getActiveBlogEntries()
+    }
+
+    fun getAllUnsynced(): LiveData<List<BlogEntry>>{
+        return blogEntriesRepository.getBlogEntriesWith(synced = false)
     }
 
     fun getDataCount() : Int {
         return blogEntriesRepository.getDataCount()
     }
 
-    fun create(title : String, bodyText : String, cardColor : Int) : Flowable<Long> {
+    fun create(title : String, bodyText : String, cardColor : Int, uid: Int? = null) : Flowable<Long> {
         val fileName = UUID.randomUUID().toString() + ".body"
         return writeBody(fileName, bodyText).flatMapSingle {
-            blogEntriesRepository.createBlogEntry(
-                BlogEntry(
-                    title = title,
-                    bodyPath = it,
-                    cardColor = cardColor
-                )
+            val newBlogEntry = BlogEntry(
+                title = title,
+                bodyPath = it,
+                cardColor = cardColor
             )
+            if (uid != null) newBlogEntry.uid = uid
+            blogEntriesRepository.createBlogEntry(newBlogEntry)
         }
     }
 

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/services/BlogEntriesSyncingService.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/services/BlogEntriesSyncingService.kt
@@ -1,0 +1,91 @@
+package ar.edu.unq.pdes.myprivateblog.services
+
+import android.content.Context
+import android.graphics.Color
+import ar.edu.unq.pdes.myprivateblog.data.BlogEntry
+import ar.edu.unq.pdes.myprivateblog.data.EntityID
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import org.threeten.bp.OffsetDateTime
+import java.io.File
+import java.io.Serializable
+import javax.inject.Inject
+
+class BlogEntriesSyncingService @Inject constructor (
+    val blogEntriesService: BlogEntriesService,
+    val context: Context
+){
+    private val db: FirebaseFirestore by lazy { FirebaseFirestore.getInstance() }
+
+    fun uploadUnsyncedBlogEntries() {
+        val user = FirebaseAuth.getInstance().currentUser
+        if (user != null) {
+            val userUid = user.uid
+            blogEntriesService.getAllUnsynced().observeForever { list ->
+                db.runBatch { batch ->
+                    list.forEach {
+                        val userBlogEntrysRef = db
+                            .document("users/$userUid")
+                            .collection("blogEntries")
+                            .document(it.uid.toString())
+                        batch.set(
+                            userBlogEntrysRef,
+                            convertForUploading(it),
+                            SetOptions.merge()
+                        )
+                    }
+                }.addOnCompleteListener {
+                    if (it.isSuccessful) {
+                        list.forEach { blogEntriesService.update(it.copy(synced = true)) }
+                    }
+                }
+            }
+        }
+    }
+
+    fun fetchAndStoreBlogEntries() {
+        val user = FirebaseAuth.getInstance().currentUser
+        if (user != null) {
+            val userUid = user.uid
+            db.document("users/$userUid")
+                .collection("blogEntries")
+                .whereEqualTo("deleted", false)
+                .get()
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        task.result?.forEach { it ->
+                            val blogEntry = it.toObject(BlogEntryFirestore::class.java)
+                            blogEntriesService.create(
+                                blogEntry.title!!,
+                                blogEntry.body!!,
+                                blogEntry.cardColor!!,
+                                blogEntry.uid
+                            )
+                        }
+                    }
+                }
+        }
+    }
+
+    private fun convertForUploading (blogEntry: BlogEntry): BlogEntryFirestore {
+        val content = File(context?.filesDir, blogEntry.bodyPath).readText()
+        return BlogEntryFirestore(
+            blogEntry.uid,
+            blogEntry.title,
+            content,
+            blogEntry.imagePath,
+            blogEntry.deleted,
+            blogEntry.date,
+            blogEntry.cardColor
+        )
+    }
+}
+
+private class BlogEntryFirestore(var uid: EntityID? = null,
+                                 var title: String? = "",
+                                 var body: String? = "",
+                                 var imagePath: String? = "",
+                                 var deleted: Boolean? = false,
+                                 var date: OffsetDateTime? = null,
+                                 var cardColor: Int? = Color.WHITE): Serializable


### PR DESCRIPTION
> Added integration with Firebase Firestore. Alter BlogEntry model with migration -> added synced field. Created logic for uploading and fetching/creating blog entries from remote DB.

Este PR proveé:
- Agregación de dependencias para Firestore
- Se modifica archivo de servicios de google para añadir huella digital propia
- Se crea service con lógica de syncing para subir registros no sincronizados y descargar registros no borrados
- Se modifica la entidad BlogEntry -> agrega campo `synced` (con migración 1 -> 2 correspondiente)

**Importante:** por el momento la lógica no está conectada a ninguna pantalla, por lo que no está habilitada. Se podría agregar la lógica de upload en la creación de un post o en el botón de syncing planeado para estar en el menú desplegable. Se debería averiguar bien como poner la descarga de post, esto debería ser cuando el usuario instala la aplicación por primera vez e inicia sesión.