### PR TITLE
Sync Logic

### DIFF
--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/MainActivityViewModel.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/MainActivityViewModel.kt
@@ -1,10 +1,16 @@
 package ar.edu.unq.pdes.myprivateblog
 
 import androidx.lifecycle.ViewModel
+import ar.edu.unq.pdes.myprivateblog.services.BlogEntriesSyncingService
+import ar.edu.unq.pdes.myprivateblog.services.EncryptionService
+import ar.edu.unq.pdes.myprivateblog.services.drive.GoogleDriveService
 import javax.inject.Inject
 
 class MainActivityViewModel  @Inject constructor(
     /* add injectable dependencies here */
+    val encryptionService: EncryptionService,
+    val blogEntriesSyncingService: BlogEntriesSyncingService,
+    val googleDriveService: GoogleDriveService
 ) : ViewModel() {
 
 }

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/screens/post_edit/PostEditViewModel.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/screens/post_edit/PostEditViewModel.kt
@@ -25,7 +25,7 @@ class PostEditViewModel @Inject constructor(
         val postSecure = post.value!!
         return blogEntriesService.writeBody(postSecure.bodyPath!!, bodyText)
             .flatMapSingle {
-                blogEntriesService.update(postSecure.copy(cardColor = cardColor.value!!)).toSingle { it }
+                blogEntriesService.update(postSecure.copy(cardColor = cardColor.value!!, synced = false)).toSingle { it }
             }
             .compose(RxSchedulers.flowableAsync())
             .subscribe {

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/screens/posts_listing/PostsListingFragment.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/screens/posts_listing/PostsListingFragment.kt
@@ -43,8 +43,6 @@ class PostsListingFragment : BaseFragment() {
 
             posts_list_recyclerview.layoutManager = LinearLayoutManager(context)
         })
-
-        viewModel.sync(this)
     }
 
     fun setView(){

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/screens/posts_listing/PostsListingViewModel.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/screens/posts_listing/PostsListingViewModel.kt
@@ -16,27 +16,10 @@ import javax.inject.Inject
 
 class PostsListingViewModel @Inject constructor(
     blogEntriesService: BlogEntriesService,
-    private val blogEntriesSyncingService: BlogEntriesSyncingService,
-    val encryptionService: EncryptionService,
-    private val googleDriveService: GoogleDriveService,
     context: Context
 ): BaseViewModel(blogEntriesService, context) {
 
     val posts: LiveData<List<BlogEntry>> by lazy {
         blogEntriesService.getAll()
     }
-
-    fun sync(fragment: BaseFragment) {
-        if (SYNCING_FEATURE_ENABLED) {
-            val secretKey = encryptionService.retrieveSecretKey()
-            if (secretKey != null) {
-                blogEntriesSyncingService.fetchAndStoreBlogEntries(secretKey)
-            } else {
-                Snackbar.make(fragment.view!!, R.string.could_not_sync_try_again, Snackbar.LENGTH_LONG)
-                    .show();
-                googleDriveService.fetchAndStoreSecretKey()
-            }
-        }
-    }
-
 }

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/screens/sign/OauthSignFragment.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/screens/sign/OauthSignFragment.kt
@@ -81,6 +81,7 @@ class OauthSignFragment : BaseFragment() {
         if(user != null)
         {
             getMainActivity().initDataAndShowSliderMenu(user.displayName!!, user.email!!, user.photoUrl)
+            viewModel.uploadPosts(this)
             goToListingPosts()
         }
     }

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/screens/sign/OauthSignViewModel.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/screens/sign/OauthSignViewModel.kt
@@ -1,15 +1,21 @@
 package ar.edu.unq.pdes.myprivateblog.screens.sign
 
 import android.content.Context
+import androidx.fragment.app.Fragment
 import ar.edu.unq.pdes.myprivateblog.BaseViewModel
+import ar.edu.unq.pdes.myprivateblog.R
 import ar.edu.unq.pdes.myprivateblog.services.BlogEntriesService
+import ar.edu.unq.pdes.myprivateblog.services.BlogEntriesSyncingService
 import ar.edu.unq.pdes.myprivateblog.services.EncryptionService
 import ar.edu.unq.pdes.myprivateblog.services.drive.GoogleDriveService
+import com.google.android.material.snackbar.Snackbar
 import javax.inject.Inject
 
 class OauthSignViewModel @Inject constructor(
     blogEntriesService: BlogEntriesService,
     private val googleDriveService: GoogleDriveService,
+    private val blogEntriesSyncingService: BlogEntriesSyncingService,
+    private val encryptionService: EncryptionService,
     context: Context
 ): BaseViewModel(blogEntriesService, context) {
 
@@ -19,4 +25,17 @@ class OauthSignViewModel @Inject constructor(
         }
     }
 
+    fun uploadPosts(fragment: Fragment) {
+        if (SYNCING_FEATURE_ENABLED) {
+            val secretKey = encryptionService.retrieveSecretKey()
+            if (secretKey != null) {
+                blogEntriesSyncingService.uploadUnsyncedBlogEntries(secretKey)
+            } else {
+                Snackbar.make(
+                    fragment.view!!,
+                    R.string.could_not_sync_try_again, Snackbar.LENGTH_LONG)
+                    .show();
+            }
+        }
+    }
 }

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/services/BlogEntriesService.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/services/BlogEntriesService.kt
@@ -62,7 +62,7 @@ class BlogEntriesService @Inject constructor(
     }
 
     fun changeLogicalDelete(blogEntry: BlogEntry, delete: Boolean) : Completable =
-        blogEntriesRepository.updateBlogEntry(blogEntry.copy( deleted = delete)).observeOn(AndroidSchedulers.mainThread())
+        blogEntriesRepository.updateBlogEntry(blogEntry.copy( deleted = delete, synced = false)).observeOn(AndroidSchedulers.mainThread())
 
     fun logicalDelete(blogEntry: BlogEntry) : Completable = changeLogicalDelete(blogEntry, true)
     fun undoLogicalDelete(blogEntry: BlogEntry) : Completable = changeLogicalDelete(blogEntry, false)

--- a/app/src/main/res/menu/drawer_menu.xml
+++ b/app/src/main/res/menu/drawer_menu.xml
@@ -5,12 +5,10 @@
 
     <group android:checkableBehavior="single">
 
-<!-- TODO: enlazar sync_button a funcionalidad
         <item
             android:id="@+id/sync_button"
             android:title="Sync"
             android:icon="@drawable/ic_action_sync" />
--->
 
         <item
             android:id="@+id/logout_button"


### PR DESCRIPTION
Se agrega lógica de sincronización para subir posts al loguearse y descargar post al oprimir el boton _sync_ en el drawer menu.

Se cambió la lógica para marcar el campo synced de los posts en false cada vez que sufren alguna modificación (create/edit/delete).